### PR TITLE
April Fools easter egg + timezone fixes

### DIFF
--- a/SetGame.test.ts
+++ b/SetGame.test.ts
@@ -275,24 +275,43 @@ describe('SetGame', () => {
     });
   });
 
+  const APRIL_FOOLS_BOARD_SIZE = 20;
+  const APRIL_FOOLS_SET_COUNT = 15;
+
   describe('multi-year board generation', () => {
     it('should generate valid boards for next five years from today', () => {
       const today = new Date('2025-08-09'); // Using today's date from env
-      
+
       // Test daily seeds for the next 5 years
       for (let year = 0; year < 1; year++) {
         for (let day = 0; day < 365; day++) {
           const testDate = new Date(today);
           testDate.setFullYear(today.getFullYear() + year);
           testDate.setDate(today.getDate() + day);
-          
+
           const seed = testDate.toISOString().split('T')[0]; // YYYY-MM-DD format
+
+          // Skip April Fools - tested separately
+          if (seed.endsWith('04-01')) continue;
+
           const game = new SetGame(seed);
-          
+
           // Fail immediately if requirements aren't met
           expect(game.board.cards.size).toBe(BOARD_SIZE);
           expect(game.board.sets.size).toBe(SET_COUNT);
         }
+      }
+    });
+
+    it('should generate april fools boards for the next five april fools days', () => {
+      const startYear = new Date().getFullYear();
+
+      for (let i = 0; i < 5; i++) {
+        const seed = `${startYear + i}-04-01`;
+        const game = new SetGame(seed);
+
+        expect(game.board.cards.size).toBe(APRIL_FOOLS_BOARD_SIZE);
+        expect(game.board.sets.size).toBe(APRIL_FOOLS_SET_COUNT);
       }
     });
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ const AppInner: React.FC = () => {
   }, []);
 
   const game = useMemo(() => {
-    const seed = searchParams.get("seed") || gameDate.toISOString().split("T")[0];
+    const seed = searchParams.get("seed") || gameDate.toLocaleDateString('en-CA');
     const shouldLoad = searchParams.has("load");
 
     // Update URL with seed param if not already present

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,7 +101,6 @@ const AppInner: React.FC = () => {
       year: "numeric",
       month: "long",
       day: "numeric",
-      timeZone: "utc",
     }).format(gameDate);
   }, [gameDate]);
 

--- a/src/SetGame.ts
+++ b/src/SetGame.ts
@@ -80,7 +80,10 @@ export class SetGame {
 
   constructor(seed: string) {
     this.seed = seed;
-    this.board = generateRandomBoard(BOARD_SIZE, SET_COUNT, seed);
+    const isAprilFools = seed.endsWith('04-01');
+    const boardSize = isAprilFools ? 20 : BOARD_SIZE;
+    const setCount = isAprilFools ? 15 : SET_COUNT;
+    this.board = generateRandomBoard(boardSize, setCount, seed);
     this.startTime = new Date();
     this.endTime = null;
     this.foundSets = Set([]);


### PR DESCRIPTION
## Summary
- When the seed ends in `04-01`, the board uses 20 cards and 15 sets as an April Fools easter egg
- Fix seed generation using `toLocaleDateString('en-CA')` instead of `toISOString()` to respect the user's local timezone
- Fix game header date display by removing `timeZone: 'utc'` override from `Intl.DateTimeFormat`
- Update multi-year board generation test to skip April 1st dates and add dedicated April Fools tests for the next 5 years

🤖 Generated with [Claude Code](https://claude.com/claude-code)